### PR TITLE
Take the invoice month into account for the 24h query.

### DIFF
--- a/gcp_cost_report/main.py
+++ b/gcp_cost_report/main.py
@@ -55,6 +55,8 @@ FROM
     WHERE
       _PARTITIONTIME >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY)
       AND export_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+      AND invoice.month = FORMAT_TIMESTAMP("%Y%m", CURRENT_TIMESTAMP(),
+                                           "{QUERY_TIME_ZONE}")
     GROUP BY
       project.id,
       currency


### PR DESCRIPTION
Tax for the last month gets invoiced on the 2nd of the month,
but it's confusing to count that for the current month's stats.